### PR TITLE
defensive check as outputPath is not guaranteed to be a string

### DIFF
--- a/eleventy.js
+++ b/eleventy.js
@@ -14,7 +14,7 @@ module.exports = (eleventyConfig) => {
   eleventyConfig.addTransform(
     'eleventy-plugin-helmet',
     async (content, outputPath) => {
-      if (typeof outputPath === 'string' && outputPath.endsWith('.html')) {
+      if (outputPath.endsWith?.('.html')) {
         const { html } = await pipeline.process(content);
         return html;
       }

--- a/eleventy.js
+++ b/eleventy.js
@@ -14,7 +14,7 @@ module.exports = (eleventyConfig) => {
   eleventyConfig.addTransform(
     'eleventy-plugin-helmet',
     async (content, outputPath) => {
-      if (outputPath.endsWith('.html')) {
+      if (typeof outputPath === 'string' && outputPath.endsWith('.html')) {
         const { html } = await pipeline.process(content);
         return html;
       }


### PR DESCRIPTION
See https://github.com/11ty/eleventy/issues/653 for more details.

As it stands, this plugin transform breaks builds that try to avail of the 11ty `permalink: false` API that is used for things like draft posts.